### PR TITLE
Fix for when steam profile url contains parameters

### DIFF
--- a/js/profile_page.js
+++ b/js/profile_page.js
@@ -2,7 +2,10 @@ var rep_site = "https://rep.tf/";
 
 //add button on steam profile
 function addRepTF(){
-	var steamURL = window.location.href.split('/');
+	// https://steamcommunity.com + /id/[Vanity URL]/
+	// or https://steamcommunity.com + /profiles/[Community ID]/
+	var steamURL = window.location.origin + window.location.pathname;
+	steamURL = steamURL.split('/');
 	var steamID = steamURL[steamURL.length - 1] == '' ? steamURL[steamURL.length - 2] : steamURL.pop();
 	//console.log(steamID);
 


### PR DESCRIPTION
This PR fixes a case when the steam profile URL contains extra reference parameters.

For example, the second google search result for https://www.google.com/search?q=rangod+yt leads to https://steamcommunity.com/id/Rangoated/?utm_source=SteamLadder.com which includes a utm_source parameter for google analytics. The current extension improperly links to https://rep.tf/?utm_source=SteamLadder.com instead of the steam id.

